### PR TITLE
Edit the fix for Blue Archive crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,40 @@ ARCH:
 
 #### 9、Unsupported applications
 1.Blue Archive (Can open the title page, but it crashes on loading.)
-- (PrimeOS 2.1.2 has fixed this bug and you can use it, or you can extract libhoudini from PrimeOS.iso and refer to the template branch to build.)
+- Due to app's data is not recognized it will make the game crash on loading. To fix this, there're 2 solutions :
+  + Make a script that set data permission to 777 whenever an app is being opened (PrimeOS method - **NOT RECOMMEND**)
+    * Cherry-pick these two commits :
+    https://github.com/supremegamers/device_generic_common/commit/2d47891376c96011b2ee3c1ccef61cb48e15aed6
+    https://github.com/supremegamers/android_frameworks_base/commit/24a08bf800b2e461356a9d67d04572bb10b0e819
+   
+    Result : Tested by [SGNight](https://github.com/SGNight) using ProjectSakura-x86
+   ![Result](https://cdn.discordapp.com/attachments/631759304097267712/967155258985943090/IMG_20220423_013402.jpg)
+   
+   + Use bind mounting file-systems (**RECOMMEND**)
+   
+   The proper way is to use file-systems such as `sdcardfs` or `esdfs` so that it can bind mount both apps data or obb correctly. This method is still being used by Android devices today.      
+   ***This method is for people who can be able to compile custom Android-x86 images***
+
+     * Find a kernel that include the file-systems :
+        
+        ** For `sdcardfs`, check out [maurossi](https://github.com/maurossi/linux) or [youling257](https://github.com/youling257/android-mainline) repo : 
+        (recommend to set `CONFIG_SDCARD_FS` to =y instead of =m)
+        
+        ** For `esdfs`, check out [HMTheBoy154](https://github.com/hmtheboy154/Darkmatter-kernel) (umbral branch) or [youling257](https://github.com/youling257/android-mainline) (5.18 branch and above). `esdfs` and `pkglist` are pulled from ChromiumOS's third_party kernel repo.
+        
+    * Go to device/generic/common and revert [this commit](https://github.com/supremegamers/device_generic_common/commit/ff34d6d549f026156188cf1467f26628e5cac658)
+    
+    ***(These next step are required for people who want to use esdfs instead, which [HMTheBoy154](https://github.com/hmtheboy154/) recommend***
+    * Still in device/generic/common, open device.mk and add these line 
+    ```
+    PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+    ro.sys.sdcardfs=false \
+    persist.sys.sdcardfs=force_off
+    ```
+    
+    * Go to system/vold, cherry-pick [this commit](https://github.com/supremegamers/platform_system_vold/commit/17ab73250d5acee423bd98fc885f87783baf9bd7) 
+    
+    Result : Tested by [HMTheBoy154](https://github.com/hmtheboy154) using BlissOS 15.6 (Android 12L)
+    ![photo_2022-07-19_14-01-19](https://user-images.githubusercontent.com/39849246/179693211-a6a711a0-a968-418e-bfb0-aef289d34f54.jpg)
+
+    


### PR DESCRIPTION
Clarify the actual reason why PrimeOS can be able to run, also adding another method which is better but require building custom images

(This will not only be able to fix Blue Archive, but also other games like Arknights or PVZ2)